### PR TITLE
Adjust test data to the new behavior introduced by d5a6dcd5

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -31,7 +31,7 @@ func TestReader(t *testing.T) {
 	}
 }
 
-const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r\n"
+const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r6/6\r\n"
 
 // testReader is a test structure to help with testing the Reader by
 // returning fixed slices of data.


### PR DESCRIPTION
Hi 

in commit d5a6dcd580b3809943ef1d27997692dbd6339ecd the behavior of
finishProgress() changed so that the last update is drawed twice. This breaks the test execution when running go test.

I am not sure if the behavoir changed unintended or if the test should be updated. I the latter case please review this pull request.

best wishes,
Matthias
