### PR TITLE
draw: export byte formatter

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -60,7 +60,7 @@ var byteUnits = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 // DrawTextFormatBytes is a DrawTextFormatFunc that formats the progress
 // and total into human-friendly byte formats.
 func DrawTextFormatBytes(progress, total int64) string {
-	return fmt.Sprintf("%s/%s", byteUnitStr(progress), byteUnitStr(total))
+	return fmt.Sprintf("%s/%s", ByteUnitStr(progress), ByteUnitStr(total))
 }
 
 // DrawTextFormatBar returns a DrawTextFormatFunc that draws a progress
@@ -84,11 +84,12 @@ func DrawTextFormatBar(width int64) DrawTextFormatFunc {
 		return fmt.Sprintf(
 			"[%s%s]",
 			strings.Repeat("=", int(current)),
-			strings.Repeat(" ", int(width - current)))
+			strings.Repeat(" ", int(width-current)))
 	}
 }
 
-func byteUnitStr(n int64) string {
+// ByteUnitStr pretty prints a number of bytes.
+func ByteUnitStr(n int64) string {
 	var unit string
 	size := float64(n)
 	for i := 1; i < len(byteUnits); i++ {


### PR DESCRIPTION
In rkt, if we pull something that has no Content-Length header, we would like to have alternative progress bar. By exporting ByteUnitStr, we can ignore the total int and only print the progress formatted.

Example formatfunc:

``` go
    fmtfunc := func(progress, total int64) string {
        if total == 0 {
            return fmt.Sprintf(
                "%s: %s of an unknown size",
                prefix,
                ioprogress.ByteUnitStr(progress),
            )
        }
        return fmt.Sprintf(
            "%s: %s %s",
            prefix,
            bar(progress, total),
            ioprogress.DrawTextFormatBytes(progress, total),
        )
    }
```

Ideally it would be nice to have an unbounded progress bar when there was a total of 0, but this works for now.

@mitchellh PTAL
