### PR TITLE
DrawTerminalf: more specific new line trigger

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -34,7 +34,7 @@ func DrawTerminalf(w io.Writer, f DrawTextFormatFunc) DrawFunc {
 	var maxLength int
 
 	return func(progress, total int64) error {
-		if progress == -1 || total == -1 {
+		if progress == -1 && total == -1 {
 			_, err := fmt.Fprintf(w, "\n")
 			return err
 		}
@@ -84,7 +84,7 @@ func DrawTextFormatBar(width int64) DrawTextFormatFunc {
 		return fmt.Sprintf(
 			"[%s%s]",
 			strings.Repeat("=", int(current)),
-			strings.Repeat(" ", int(width - current)))
+			strings.Repeat(" ", int(width-current)))
 	}
 }
 

--- a/draw_test.go
+++ b/draw_test.go
@@ -47,8 +47,8 @@ func TestDrawTextFormatBar(t *testing.T) {
 }
 
 func TestDrawTextFormatBytes(t *testing.T) {
-	cases := []struct{
-		P, T int64
+	cases := []struct {
+		P, T   int64
 		Output string
 	}{
 		{

--- a/reader.go
+++ b/reader.go
@@ -84,6 +84,8 @@ func (r *Reader) finishProgress() {
 	if !r.lastDraw.IsZero() {
 		f := r.drawFunc()
 		f(r.progress, r.Size)
+
+		// Print a newline
 		f(-1, -1)
 
 		// Reset lastDraw so we don't finish again


### PR DESCRIPTION
rkt feeds ContentLength straight into the reader. If Content-Length is unknown net/http returns it as -1, thus causing the newline to get trigger repeatedly.
